### PR TITLE
Fixes option detection for timeout value.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -225,7 +225,7 @@ int main(int argc, char *argv[]) {
   int n_threads = (opts->has_threads() ? atoi(opts->get_threads().c_str()) : 1);
 
   /* default 5 sec timeout */
-  int timeout = (opts->has_threads() ? atoi(opts->get_timeout().c_str()) : 5);
+  int timeout = (opts->has_timeout() ? atoi(opts->get_timeout().c_str()) : 5);
 
   /* default shift 20 */
   uint16_t shift = (opts->has_shift() ?  atoi(opts->get_shift().c_str()) : 20);


### PR DESCRIPTION
It was checking has_threads instead of has_timeout, Minor copy paste mishap.

Note: haven't compiled or tested, I just noticed that when I was looking thru the code to see what the default options were for the prime sieve tweaking so i knew where to start from if i wanted to play around with them, and figured I'd make a quick pr.
